### PR TITLE
Improve visibility for restingPosition letters.

### DIFF
--- a/logic/main.css
+++ b/logic/main.css
@@ -555,7 +555,8 @@ input:checked + .slider:before {
 }
 
 .restingPosition {
-	text-decoration: underline;
+	text-decoration-line: underline;
+	text-underline-offset: 4px;
 }
 
 .active {


### PR DESCRIPTION
The current CSS keeps the restingPosition indicator incredibly close to the letters. As a beginner COLEMAK-DH user, differentiating between the T and the I is rather difficult. So difficult I forked the repo just to make this one PR. 😇 

## Original
![image](https://user-images.githubusercontent.com/19361023/189555963-ce16af6f-74b1-442b-938b-382ba300513b.png)

## Modified 
![image](https://user-images.githubusercontent.com/19361023/189555978-f131b28f-16a5-4140-9ed7-03b59d39e833.png)
