### PR TITLE
Use previously selected options for layout and keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	<div id='selectors'>
 		<div>
-			<select id='layout' autocomplete="off">
+			<select id='layout' autocomplete="on">
 				<option value='colemak'>Colemak</option>
 				<option value='colemakdh'>Colemak-DH</option>
 				<option disabled/>
@@ -46,7 +46,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		</div>
 
 		<div>
-			<select id='keyboard' autocomplete="off">
+			<select id='keyboard' autocomplete="on">
 				<option value='ansi'>ANSI</option>
 				<option value='iso'>ISO</option>
 				<option value='ortho'>Ortho</option>


### PR DESCRIPTION
This patch enables the autocomplete attribute on layout and keyboard `<select>` so that the selected element is autocompleted with a previously selected option on reload.